### PR TITLE
Allow checking multiple permissions at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ A couple of helper scripts are provided to aid in searching/listing of the outpu
 
 * `list-all-permissions.sh` grabs the unique list of all permissions contained in all roles fetched
 * `list-alpha/beta/ga-roles.sh` lists the roles labeled by GCP as alpha, beta, or GA (generally available)
-* `list-roles-with-permission.sh <api.resource.verb>` lists the roles that contain a specific permission passed by the first argument. e.g.: `./list-roles-with-permission.sh container.clusters.get`
+* `list-roles-with-permissions.sh <api.resource.verb1>[ <api.resource.verbN>]` lists the roles that contain all of the specific permissions passed as one or more arguments. e.g.: `./list-roles-with-permissions.sh autoscaling.sites.writeMetrics logging.logEntries.create`
+* `list-roles-with-permission.sh <api.resource.verb>` compatibility alias for the single-permission version of `list-roles-with-permissions.sh`. e.g.: `./list-roles-with-permission.sh container.clusters.get`
 * `list-permissions-of-role.sh <role.name>` lists the permissions contained by the role named `<role.name>`.  e.g. `./list-roles-with-permission.sh container.admin` (no need to prepend the `roles/`)

--- a/list-roles-with-permission.sh
+++ b/list-roles-with-permission.sh
@@ -1,14 +1,4 @@
 #!/usr/bin/env bash
 
-if [ "$#" -ne 1 ]
-then
-  echo "Error: Must specify the permission to search for"
-  echo ""
-  echo "e.g: $0 resourcemanager.projects.get"
-  echo ""
-  exit 1
-fi
-
-source ./lib/helper.sh
-
-cat roles/* | jq -r --arg PERM "$1" 'select(.includedPermissions!=null and (.includedPermissions[] | contains($PERM))) | "\(.name)"'
+# Note: this is just a compatibility alias to not break pipelines using the old single-permission version
+source ./list-roles-with-permissions.sh

--- a/list-roles-with-permissions.sh
+++ b/list-roles-with-permissions.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+if [ "$#" -lt 1 ]
+then
+  echo "Error: Must specify at least one permission to search for. Specifying multiple permissions will return roles matching ALL of the supplied permissions."
+  echo ""
+  echo "e.g: $0 autoscaling.sites.writeMetrics logging.logEntries.create"
+  echo ""
+  exit 1
+fi
+
+source ./lib/helper.sh
+
+arg_json=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${@}")
+
+cat roles/* | jq -r "select(.includedPermissions!=null and (.includedPermissions | contains($arg_json))) | \"\(.name)\""


### PR DESCRIPTION
I know this is an old repo, but I found it useful and wanted to share a helpful improvement.

Currently the `list-roles-with-permission.sh` script only allows checking a single permission. I was working with the output of the GCP Security Insights, which shows a list of recently-used permissions like this:
![image](https://github.com/darkbitio/gcp-iam-role-permissions/assets/51453105/0c1afdb6-25ca-4310-942e-9ebfa61ff47a)

I wanted to check which role(s) provided _**all**_ of those permissions without having to check and compare one at a time. So I modified your script to produce a JSON array from variable arguments, and do an array-to-array comparison using `jq`.

I found the current name to be confusing with this new functionality, so to maintain compatibility I modified that file to only be an alias to the new plural version of the script. Docs are also updated.