### PR TITLE
allow both [roles/]<role> queries

### DIFF
--- a/list-permissions-of-role.sh
+++ b/list-permissions-of-role.sh
@@ -11,4 +11,8 @@ fi
 
 source ./lib/helper.sh
 
-cat roles/* | jq -r --arg ROLE "roles/$1" 'select(.name==$ROLE and .includedPermissions!=null and .includedPermissions!=[]) | .includedPermissions[] | "\(.)"'
+if [[ "$1" =~ ^roles ]]; then
+  cat roles/* | jq -r --arg ROLE "$1" 'select(.name==$ROLE and .includedPermissions!=null and .includedPermissions!=[]) | .includedPermissions[] | "\(.)"'
+else
+  cat roles/* | jq -r --arg ROLE "roles/$1" 'select(.name==$ROLE and .includedPermissions!=null and .includedPermissions!=[]) | .includedPermissions[] | "\(.)"'
+fi


### PR DESCRIPTION
I love this project ❤️ I use it on a daily basis 😄 
A small change for the following use cases, which I often run into.

**tl;dr** allow `list-permissions-of-role` to accept parameter as `compute.networkUser` or `roles/compute.networkUser` (the latter case allows for a copy and paste, see below).

```shell
# both work with this change
./list-permissions-of-role.sh roles/compute.networkUser
./list-permissions-of-role.sh compute.networkUser
```

**Use case:**
We see a permission error and need another IAM permission, e.g., `compute.addresses.list`.

We find suitable roles (around 54) with `./list-roles-with-permission.sh compute.addresses.list | sort -u`.

Often, the next question is which of these roles is appropriate by looking into the set of permissions of a role; however, I cannot copy and paste the output from `list-roles-with-permissions.sh` to `list-permissions-of-role.sh`.
